### PR TITLE
Fixes divide by zero error in getbottomrow.php

### DIFF
--- a/inc/getbottomrow.php
+++ b/inc/getbottomrow.php
@@ -86,7 +86,10 @@ foreach ($premium as $key => $value) {
 		$value['label'] = 'F2P';
 	}
 	$premium[$key]['label'] = $value['label'];
-	$premium[$key]['value'] = number_format($value['value']/$p_total*100,2);
+	if(!$p_total == 0)
+		$premium[$key]['value'] = number_format($value['value']/$p_total*100,2);
+	else
+		$premium[$key]['value'] = 0;
 }
 
 $country = json_encode($country);


### PR DESCRIPTION
Since this premium thing is only in TF2 and I dont use the plugin with TF2 it always caused a PHP division by zero error. I am suggesting this fix -- it's working for me.

I didn't port this fix to the other things as they can't be zero and work in all sdk2013+ games.